### PR TITLE
test(contracts): cover the deploy script predictions

### DIFF
--- a/contracts/test/scripts/DeployProtocolAdapterImplementation.t.sol
+++ b/contracts/test/scripts/DeployProtocolAdapterImplementation.t.sol
@@ -10,6 +10,9 @@ import {RiscZeroRouterFixture} from "../fixtures/RiscZeroRouterFixture.sol";
 
 /// @notice Checks the implementation deploy script.
 contract DeployProtocolAdapterImplementationTest is RiscZeroRouterFixture {
+    /// @dev The local development chain, which has no RISC Zero deployment.
+    uint256 internal constant _UNSUPPORTED_CHAIN_ID = 31337;
+
     function test_run_deploys_deterministically() public {
         _deployRiscZeroRouter();
 
@@ -43,5 +46,21 @@ contract DeployProtocolAdapterImplementationTest is RiscZeroRouterFixture {
             )
         );
         script.run();
+    }
+
+    function test_predict_matches_the_address_run_deploys() public {
+        _deployRiscZeroRouter();
+
+        DeployProtocolAdapterImplementation script = new DeployProtocolAdapterImplementation();
+        (address predicted,) = script.predict(block.chainid);
+
+        assertEq(script.run(), predicted, "prediction differs from the deployed implementation");
+    }
+
+    function test_predict_reverts_on_an_unsupported_network() public {
+        DeployProtocolAdapterImplementation script = new DeployProtocolAdapterImplementation();
+
+        vm.expectRevert(abi.encodeWithSelector(SupportedNetworks.UnsupportedNetwork.selector, _UNSUPPORTED_CHAIN_ID));
+        script.predict(_UNSUPPORTED_CHAIN_ID);
     }
 }

--- a/contracts/test/scripts/DeployProtocolAdapterProxy.t.sol
+++ b/contracts/test/scripts/DeployProtocolAdapterProxy.t.sol
@@ -63,6 +63,32 @@ contract DeployProtocolAdapterProxyTest is RiscZeroRouterFixture, DeploymentsFix
         script.run({isProduction: false});
     }
 
+    function test_predict_matches_the_addresses_run_deploys() public {
+        _deployRiscZeroRouter();
+
+        DeployProtocolAdapterProxy script = new DeployProtocolAdapterProxy();
+
+        (address predictedProxy, address predictedImplementation) = script.predict({isProduction: false});
+        (address proxy, address implementation,,) = script.run({isProduction: false});
+
+        assertEq(proxy, predictedProxy, "staging: prediction differs from the deployed proxy");
+        assertEq(
+            implementation, predictedImplementation, "staging: prediction differs from the deployed implementation"
+        );
+
+        (address predictedProductionProxy,) = script.predict({isProduction: true});
+        (address productionProxy,,,) = script.run({isProduction: true});
+
+        assertEq(productionProxy, predictedProductionProxy, "production: prediction differs from the deployed proxy");
+    }
+
+    function test_environmentName_names_the_environments() public {
+        DeployProtocolAdapterProxy script = new DeployProtocolAdapterProxy();
+
+        assertEq(script.environmentName({isProduction: false}), "staging", "staging environment name differs");
+        assertEq(script.environmentName({isProduction: true}), "production", "production environment name differs");
+    }
+
     /// @notice Runs the deploy script for the environment and checks that the proxy lands at the predicted
     /// deterministic address, delegates to a deployed implementation, and is initialized with the environment owner.
     /// @param isProduction Whether to deploy the production or the staging environment proxy.


### PR DESCRIPTION
## What

Covers `predict` on both deploy scripts, `environmentName`, and the `UnsupportedNetwork` revert.

## Why

The tests re-derived the expected addresses with `vm.computeCreate2Address` instead of calling the shipped `predict`, so a drift between the two went unnoticed, and `UnsupportedNetwork` was asserted nowhere. Both deploy scripts now reach 100% lines, statements, branches and functions.
