### PR TITLE
docs(contracts): state the year each contract was created

### DIFF
--- a/contracts/script/DeployProtocolAdapterImplementation.s.sol
+++ b/contracts/script/DeployProtocolAdapterImplementation.s.sol
@@ -10,7 +10,7 @@ import {Upgrades} from "openzeppelin-foundry-upgrades-0.4.2/src/Upgrades.sol";
 import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
 
 /// @title DeployProtocolAdapterImplementation
-/// @author Anoma Foundation, 2025
+/// @author Anoma Foundation, 2026
 /// @notice A script to deploy the protocol adapter implementation on supported networks.
 /// @dev `SupportedNetworks` supplies the networks and their RISC Zero verifier router addresses
 /// (see https://dev.risczero.com/api/3.0/blockchain-integration/contracts/verifier).

--- a/contracts/script/DeployProtocolAdapterProxy.s.sol
+++ b/contracts/script/DeployProtocolAdapterProxy.s.sol
@@ -8,7 +8,7 @@ import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
 import {DeployProtocolAdapterImplementation} from "./DeployProtocolAdapterImplementation.s.sol";
 
 /// @title DeployProtocolAdapterProxy
-/// @author Anoma Foundation, 2025
+/// @author Anoma Foundation, 2026
 /// @notice A script to deploy the protocol adapter implementation and an ERC-1967 proxy pointing to it on supported
 /// networks.
 /// @custom:security-contact security@anoma.foundation

--- a/contracts/script/PrintProtocolAdapterVersion.s.sol
+++ b/contracts/script/PrintProtocolAdapterVersion.s.sol
@@ -6,7 +6,7 @@ import {Script} from "forge-std-1.16.2/src/Script.sol";
 import {ProtocolAdapter} from "../src/ProtocolAdapter.sol";
 
 /// @title PrintProtocolAdapterVersion
-/// @author Anoma Foundation, 2025
+/// @author Anoma Foundation, 2026
 /// @notice A script returning the version the protocol adapter source compiles to. The release flow reads it to label
 /// the published package, so that the label always describes the source it ships.
 /// @custom:security-contact security@anoma.foundation

--- a/contracts/src/libs/VerifyingKeys.sol
+++ b/contracts/src/libs/VerifyingKeys.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.30;
 
 /// @title VerifyingKeys
-/// @author Anoma Foundation, 2025
+/// @author Anoma Foundation, 2026
 /// @notice A library containing the verifying keys (RISC Zero image IDs) of the circuits the protocol adapter
 /// accepts proofs from, pinned to the `anoma-rm-risc0` circuit binaries.
 /// @custom:security-contact security@anoma.foundation


### PR DESCRIPTION
Four contracts written in 2026 named 2025 in their author tag; the year is the one a contract was first committed under, following renames, so a file that only moved keeps the year it had.