### PR TITLE
refactor(contracts): move the test-only root helpers out of MerkleTree

### DIFF
--- a/contracts/src/libs/MerkleTree.sol
+++ b/contracts/src/libs/MerkleTree.sol
@@ -2,8 +2,6 @@
 pragma solidity ^0.8.30;
 
 import {Arrays} from "@openzeppelin-contracts-5.7.0/utils/Arrays.sol";
-import {Math} from "@openzeppelin-contracts-5.7.0/utils/math/Math.sol";
-import {SafeCast} from "@openzeppelin-contracts-5.7.0/utils/math/SafeCast.sol";
 
 import {SHA256} from "../libs/SHA256.sol";
 
@@ -14,8 +12,6 @@ import {SHA256} from "../libs/SHA256.sol";
 /// (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.4.0/contracts/utils/structs/MerkleTree.sol).
 /// @custom:security-contact security@anoma.foundation
 library MerkleTree {
-    using SafeCast for uint256;
-
     struct Tree {
         uint256 _nextLeafIndex;
         bytes32[] _sides;
@@ -116,51 +112,5 @@ library MerkleTree {
     /// @return isLeft Whether this node is the left or right child.
     function isLeftChild(uint256 index) internal pure returns (bool isLeft) {
         isLeft = (index & 1) == 0;
-    }
-
-    /// @notice Computes the root of a Merkle tree.
-    /// @param leaves The leaves of the tree.
-    /// @param treeDepth The depth of the tree.
-    /// @return root The computed root.
-    /// @dev This method should only be used for trees with low depth.
-    function computeRoot(bytes32[] memory leaves, uint8 treeDepth) internal pure returns (bytes32 root) {
-        uint256 treeCapacity = uint256(1) << treeDepth; // 2^treeDepth
-
-        // Create array of full leaf set with padding if necessary
-        bytes32[] memory nodes = new bytes32[](treeCapacity);
-        for (uint256 i = 0; i < treeCapacity; ++i) {
-            if (i < leaves.length) {
-                nodes[i] = leaves[i];
-            } else {
-                nodes[i] = SHA256.EMPTY_HASH;
-            }
-        }
-
-        // Build the tree upward
-        uint256 currentLevelCapacity = treeCapacity;
-        while (currentLevelCapacity > 1) {
-            currentLevelCapacity /= 2;
-
-            for (uint256 i = 0; i < currentLevelCapacity; ++i) {
-                nodes[i] = SHA256.hash(nodes[2 * i], nodes[2 * i + 1]);
-            }
-        }
-
-        root = nodes[0];
-    }
-
-    /// @notice Computes the root of a Merkle tree using the minimal tree depth to fit all leaves.
-    /// @param leaves The leaves of the tree.
-    /// @return root The computed root.
-    /// @dev This method should only be used for trees with low depth.
-    function computeRoot(bytes32[] memory leaves) internal pure returns (bytes32 root) {
-        root = MerkleTree.computeRoot({leaves: leaves, treeDepth: computeMinimalTreeDepth(leaves.length)});
-    }
-
-    /// @notice Computes the minimal required tree depth for a number of leaves.
-    /// @param leavesCount The number of leaves.
-    /// @return treeDepth The minimal required tree depth.
-    function computeMinimalTreeDepth(uint256 leavesCount) internal pure returns (uint8 treeDepth) {
-        treeDepth = Math.log2({value: leavesCount, rounding: Math.Rounding.Ceil}).toUint8();
     }
 }

--- a/contracts/test/examples/MerkleTree.e.sol
+++ b/contracts/test/examples/MerkleTree.e.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {MerkleTree} from "../../src/libs/MerkleTree.sol";
 import {SHA256} from "../../src/libs/SHA256.sol";
+import {MerkleTreeReference} from "../libs/MerkleTreeReference.sol";
 
 contract MerkleTreeExample {
-    using MerkleTree for bytes32[];
+    using MerkleTreeReference for bytes32[];
 
     uint256 internal constant _N_LEAVES = 7;
     uint256 internal constant _N_ROOTS = 8;
@@ -104,7 +104,7 @@ contract MerkleTreeExample {
 
             _heightTwoNodes[3] = _calculateNextLevel(_heightOneNodes[3]);
 
-            _roots[3] = MerkleTree.computeRoot(_leaves[3]);
+            _roots[3] = MerkleTreeReference.computeRoot(_leaves[3]);
 
             _siblings[3] = new bytes32[][](3);
 

--- a/contracts/test/libs/MerkleTreeReference.sol
+++ b/contracts/test/libs/MerkleTreeReference.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Math} from "@openzeppelin-contracts-5.7.0/utils/math/Math.sol";
+import {SafeCast} from "@openzeppelin-contracts-5.7.0/utils/math/SafeCast.sol";
+
+import {SHA256} from "../../src/libs/SHA256.sol";
+
+/// @notice Computes a Merkle root from a complete leaf set, the straightforward way. The protocol adapter never does
+/// this: it maintains the root incrementally in `MerkleTree`. Tests use this to obtain a root the incremental
+/// implementation must reproduce.
+library MerkleTreeReference {
+    using SafeCast for uint256;
+
+    /// @notice Computes the root of a Merkle tree.
+    /// @param leaves The leaves of the tree.
+    /// @param treeDepth The depth of the tree.
+    /// @return root The computed root.
+    /// @dev This method should only be used for trees with low depth.
+    function computeRoot(bytes32[] memory leaves, uint8 treeDepth) internal pure returns (bytes32 root) {
+        uint256 treeCapacity = uint256(1) << treeDepth; // 2^treeDepth
+
+        // Create array of full leaf set with padding if necessary
+        bytes32[] memory nodes = new bytes32[](treeCapacity);
+        for (uint256 i = 0; i < treeCapacity; ++i) {
+            if (i < leaves.length) {
+                nodes[i] = leaves[i];
+            } else {
+                nodes[i] = SHA256.EMPTY_HASH;
+            }
+        }
+
+        // Build the tree upward
+        uint256 currentLevelCapacity = treeCapacity;
+        while (currentLevelCapacity > 1) {
+            currentLevelCapacity /= 2;
+
+            for (uint256 i = 0; i < currentLevelCapacity; ++i) {
+                nodes[i] = SHA256.hash(nodes[2 * i], nodes[2 * i + 1]);
+            }
+        }
+
+        root = nodes[0];
+    }
+
+    /// @notice Computes the root of a Merkle tree using the minimal tree depth to fit all leaves.
+    /// @param leaves The leaves of the tree.
+    /// @return root The computed root.
+    /// @dev This method should only be used for trees with low depth.
+    function computeRoot(bytes32[] memory leaves) internal pure returns (bytes32 root) {
+        root = computeRoot({leaves: leaves, treeDepth: computeMinimalTreeDepth(leaves.length)});
+    }
+
+    /// @notice Computes the minimal required tree depth for a number of leaves.
+    /// @param leavesCount The number of leaves.
+    /// @return treeDepth The minimal required tree depth.
+    function computeMinimalTreeDepth(uint256 leavesCount) internal pure returns (uint8 treeDepth) {
+        treeDepth = Math.log2({value: leavesCount, rounding: Math.Rounding.Ceil}).toUint8();
+    }
+}

--- a/contracts/test/libs/TxGen.sol
+++ b/contracts/test/libs/TxGen.sol
@@ -6,13 +6,13 @@ import {RiscZeroMockVerifier} from "risc0-risc0-ethereum-3.0.1/contracts/src/tes
 
 import {IProtocolAdapter} from "../../src/interfaces/IProtocolAdapter.sol";
 import {DeltaProof} from "../../src/libs/DeltaProof.sol";
-import {MerkleTree} from "../../src/libs/MerkleTree.sol";
 import {SHA256} from "../../src/libs/SHA256.sol";
 import {VerifyingKeys} from "../../src/libs/VerifyingKeys.sol";
 import {DeltaGen} from "./DeltaGen.sol";
+import {MerkleTreeReference} from "./MerkleTreeReference.sol";
 
 library TxGen {
-    using MerkleTree for bytes32[];
+    using MerkleTreeReference for bytes32[];
 
     /// @notice The resource object constituting the atomic unit of state in the Anoma protocol.
     /// @param  logicRef The hash of the resource logic function.

--- a/contracts/test/state/MerkleTree.t.sol
+++ b/contracts/test/state/MerkleTree.t.sol
@@ -6,10 +6,11 @@ import {Test} from "forge-std-1.16.2/src/Test.sol";
 import {MerkleTree} from "./../../src/libs/MerkleTree.sol";
 import {SHA256} from "./../../src/libs/SHA256.sol";
 import {MerkleTreeExample} from "./../examples/MerkleTree.e.sol";
+import {MerkleTreeReference} from "./../libs/MerkleTreeReference.sol";
 
 contract MerkleTreeTest is Test, MerkleTreeExample {
     using MerkleTree for MerkleTree.Tree;
-    using MerkleTree for bytes32[];
+    using MerkleTreeReference for bytes32[];
     using OzMerkleTree for OzMerkleTree.Bytes32PushTree;
 
     MerkleTree.Tree internal _merkleTree;
@@ -114,10 +115,10 @@ contract MerkleTreeTest is Test, MerkleTreeExample {
     function test_compare_le() public pure {
         assertEq(
             _computeMinimalTreeDepthNaive(0),
-            MerkleTree.computeMinimalTreeDepth(0),
+            MerkleTreeReference.computeMinimalTreeDepth(0),
             "naive and optimized should match for 0 leaves"
         );
-        assertEq(MerkleTree.computeMinimalTreeDepth(0), 0, "minimal tree depth for 0 leaves should be 0");
+        assertEq(MerkleTreeReference.computeMinimalTreeDepth(0), 0, "minimal tree depth for 0 leaves should be 0");
     }
 
     function test_computeMinimalTreeDepth_computes_the_right_tree_depths() public pure {
@@ -126,7 +127,9 @@ contract MerkleTreeTest is Test, MerkleTreeExample {
 
         for (uint256 i = 0; i < depths.length; ++i) {
             assertEq(
-                MerkleTree.computeMinimalTreeDepth({leavesCount: i}), depths[i], "tree depth should match expected"
+                MerkleTreeReference.computeMinimalTreeDepth({leavesCount: i}),
+                depths[i],
+                "tree depth should match expected"
             );
         }
     }
@@ -137,7 +140,7 @@ contract MerkleTreeTest is Test, MerkleTreeExample {
         for (uint256 i = 0; i < maxLeafCount; ++i) {
             assertEq(
                 _computeMinimalTreeDepthNaive({leavesCount: i}),
-                MerkleTree.computeMinimalTreeDepth({leavesCount: i}),
+                MerkleTreeReference.computeMinimalTreeDepth({leavesCount: i}),
                 "naive and optimized implementations should match"
             );
         }
@@ -152,21 +155,21 @@ contract MerkleTreeTest is Test, MerkleTreeExample {
 
             assertEq(
                 _computeMinimalTreeDepthNaive(powerOfTwo - 1),
-                MerkleTree.computeMinimalTreeDepth(powerOfTwo - 1),
+                MerkleTreeReference.computeMinimalTreeDepth(powerOfTwo - 1),
                 "should match for power of 2 minus 1"
             );
 
             // Test power of 2
             assertEq(
                 _computeMinimalTreeDepthNaive(powerOfTwo),
-                MerkleTree.computeMinimalTreeDepth(powerOfTwo),
+                MerkleTreeReference.computeMinimalTreeDepth(powerOfTwo),
                 "should match for power of 2"
             );
 
             // Test power of 2 + 1
             assertEq(
                 _computeMinimalTreeDepthNaive(powerOfTwo + 1),
-                MerkleTree.computeMinimalTreeDepth(powerOfTwo + 1),
+                MerkleTreeReference.computeMinimalTreeDepth(powerOfTwo + 1),
                 "should match for power of 2 plus 1"
             );
         }
@@ -179,7 +182,7 @@ contract MerkleTreeTest is Test, MerkleTreeExample {
         for (uint256 i = 0; i < testCases.length; i++) {
             assertEq(
                 _computeMinimalTreeDepthNaive(testCases[i]),
-                MerkleTree.computeMinimalTreeDepth(testCases[i]),
+                MerkleTreeReference.computeMinimalTreeDepth(testCases[i]),
                 "should match for large values"
             );
         }
@@ -190,7 +193,7 @@ contract MerkleTreeTest is Test, MerkleTreeExample {
         leavesCount = bound(leavesCount, 0, type(uint128).max);
 
         uint8 original = _computeMinimalTreeDepthNaive(leavesCount);
-        uint8 optimized = MerkleTree.computeMinimalTreeDepth(leavesCount);
+        uint8 optimized = MerkleTreeReference.computeMinimalTreeDepth(leavesCount);
 
         assertEq(original, optimized, "Implementations must match");
     }
@@ -200,7 +203,7 @@ contract MerkleTreeTest is Test, MerkleTreeExample {
         leavesCount = bound(leavesCount, 0, 1000);
 
         uint8 original = _computeMinimalTreeDepthNaive(leavesCount);
-        uint8 optimized = MerkleTree.computeMinimalTreeDepth(leavesCount);
+        uint8 optimized = MerkleTreeReference.computeMinimalTreeDepth(leavesCount);
 
         assertEq(original, optimized, "Implementations must match");
     }
@@ -210,7 +213,7 @@ contract MerkleTreeTest is Test, MerkleTreeExample {
         leavesCount = bound(leavesCount, 1000, 1000000);
 
         uint8 original = _computeMinimalTreeDepthNaive(leavesCount);
-        uint8 optimized = MerkleTree.computeMinimalTreeDepth(leavesCount);
+        uint8 optimized = MerkleTreeReference.computeMinimalTreeDepth(leavesCount);
 
         assertEq(original, optimized, "Implementations must match");
     }
@@ -223,7 +226,7 @@ contract MerkleTreeTest is Test, MerkleTreeExample {
     /// @notice Fuzz test - Optimized implementation only (to measure gas)
     function testFuzz_gas_optimized(uint256 leavesCount) public pure {
         leavesCount = bound(leavesCount, 0, 1000000);
-        MerkleTree.computeMinimalTreeDepth(leavesCount);
+        MerkleTreeReference.computeMinimalTreeDepth(leavesCount);
     }
 
     /// @notice Hashes two `bytes32` values.


### PR DESCRIPTION
`MerkleTree` carried three functions the protocol adapter never calls: `computeRoot(bytes32[], uint8)`, `computeRoot(bytes32[])` and `computeMinimalTreeDepth(uint256)`. They build a root from a complete leaf set, which is what tests need and the opposite of what the contract does — the contract maintains the root incrementally, one `push` at a time.

They move to `contracts/test/libs/MerkleTreeReference.sol`, beside `TxGen` and `DeltaGen`. The bodies are unchanged.

Callers, all of them tests: `TxGen`, `MerkleTreeExample`, and `MerkleTreeTest`, which uses the reference implementation as the value `push` must reproduce.

`MerkleTree` loses its `Math` and `SafeCast` imports with them, since only `computeMinimalTreeDepth` used those.

No production behaviour changes. The functions are `internal`, so nothing entered the deployed bytecode, the storage layout is untouched, and the bindings do not move.