### PR TITLE
build: drop the stale Types skip from contracts-storage-check

### DIFF
--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ contracts-lint:
 
 # Checks that the storage layout of contracts in `src` is empty.
 # `skip` is a space-separated list of contract names to ignore (contract-free files).
-contracts-storage-check *skip='Types':
+contracts-storage-check *skip='':
     #!/usr/bin/env bash
     set -euo pipefail
     cd contracts


### PR DESCRIPTION
`contracts-storage-check *skip='Types'` skipped a `Types.sol` that no longer exists in `contracts/src`. The default becomes empty, so every contract under `src` is checked. The parameter stays, for a contract that legitimately holds plain storage one day.